### PR TITLE
fixed spec.version regular expression

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
         REF: ${{ github.ref }}
       run: |
         commit_hash="$(echo ${GITHUB_SHA:0:7})"
-        sed -ie "s/\(spec\.version = \"[^\"]\+\)/\1.${commit_hash}.pre/g" *.gemspec
+        sed -ie "s/\(spec\.version \+= \+\"[^\"]\+\)/\1.${commit_hash}.pre/g" *.gemspec
         grep spec.version *.gemspec
       shell: bash
     - if: ${{ inputs.language == 'ruby' }}


### PR DESCRIPTION
Care for the number of whitespaces.
```
$ commit_hash=abc
$ echo 'spec.version = "1.0.0"' | sed -e "s/\(spec\.version \+= \+\"[^\"]\+\)/\1.${commit_hash}.pre/g"
spec.version = "1.0.0.abc.pre"
$ echo 'spec.version  =   "1.0.0"' | sed -e "s/\(spec\.version \+= \+\"[^\"]\+\)/\1.${commit_hash}.pre/g"
spec.version  =   "1.0.0.abc.pre"
```